### PR TITLE
Sprite.distance & world.raycast implementation

### DIFF
--- a/p5play.js
+++ b/p5play.js
@@ -6797,7 +6797,10 @@ p5.prototype.registerMethod('init', function p5playInit() {
 				result = {
 					hit: true,
 					sprite: body.sprite,
-					point,
+					point: createVector(
+						point.x * plScale,
+						point.y * plScale
+					),
 					normal
 				}
 

--- a/p5play.js
+++ b/p5play.js
@@ -3976,7 +3976,7 @@ p5.prototype.registerMethod('init', function p5playInit() {
 		 * @param {Sprite} otherSprite
 		 * @returns {Number} distance
 		 */
-		distance(otherSprite){
+		distanceTo(otherSprite){
 			return $.dist(this.x, this.y, otherSprite.x, otherSprite.y)
 		}
 	};


### PR DESCRIPTION
First time contribution - Some of my formatting may not be up to spec, and the minified version isn't currently included.

This PR aims to fix #280, as well as a pet peeve of mine being the lack of Sprite.distance() function.

## Sprite.distance(otherSprite)
Returns the distance to the other Sprite. How this isn't already implemented is odd to me.

## world.raycast
An implementation atop of the world.rayCast (don't get them confused! I don't know how to override the other one and still use it) that returns the closest sprite from a position and direction of a ray.

Due to limitations I've encountered [in the past](https://github.com/piqnt/planck.js/issues/270), I'm still unable to get Planck to return a list of all rays & find the closest one simultaneously. Even with `Sprite.distance`, I wasn't able to get it working.
Thus, the function currently only returns one "hit" (true/false), "sprite", "point", and "normal".
This can be remedied with the optional `excludeFunction`, detailed in a comment in the PR.

[Here's a sketch demonstrating the functionality](https://editor.p5js.org/codingMASTER398/sketches/x_QnmCD12).