### PR TITLE
add `repelFrom()` function to `Group`

### DIFF
--- a/p5play.js
+++ b/p5play.js
@@ -6266,6 +6266,14 @@ p5.prototype.registerMethod('init', function p5playInit() {
 		}
 
 		/**
+		 */
+		repelFrom() {
+			for (let s of this) {
+				s.repelFrom(...arguments);
+			}
+		}
+
+		/**
 		 * Alias for group.length
 		 * @deprecated
 		 */


### PR DESCRIPTION
This is my first time contributing, please let me know if I messed something up.
Since there's an `attractTo()` for groups I can't think of any reason why this shouldn't exist.