### PR TITLE
Fix a very specific edge-case loading images

### DIFF
--- a/p5play.js
+++ b/p5play.js
@@ -9035,7 +9035,7 @@ p5.prototype.registerMethod('init', function p5playInit() {
 		}
 		if (img) {
 			// if not finished loading, add callback to the list
-			if ((img.width == 1 && img.height == 1) || !img.pixels.length) {
+			if ((img.width <= 1 && img.height <= 1) || !img.pixels.length) {
 				if (cb) {
 					img.cbs.push(cb);
 					img.calls++;


### PR DESCRIPTION
See [this Discord thread](https://discord.com/channels/1243589297014313050/1243592745398829157/1308332841876062218).
No idea why it happens, I only know that the images with q5.js load as having a width and height of 0.

The code that I've changed used to only detect something going wrong if the width was specifically 1, not 0. This fixes that case, and makes sure that it goes on to re-load it if the width & height is 0.